### PR TITLE
Added support for search parameters (#55)

### DIFF
--- a/src/controllers/certificate.js
+++ b/src/controllers/certificate.js
@@ -203,9 +203,9 @@ const getSingle = async (req, res) => {
 		const formData = req.query.tags;
 		const decodedData = decodeURIComponent(formData);
 		const jsonObject = JSON.parse(decodedData);
-		req.query["tags"] = {"$in": jsonObject};
+		req.query['tags'] = {'$in': jsonObject};
 		}catch(e){
-			return res.status(statusCode.BAD_REQUEST).send(`Bad JSON object encoding ${e.message}`);
+			return res.status(statusCode.BAD_REQUEST).send(`Failed to get certificates: Bad fromat ${e.message}`);
 		}
 	}
 

--- a/src/controllers/certificate.js
+++ b/src/controllers/certificate.js
@@ -198,7 +198,18 @@ const getSingle = async (req, res) => {
  * @type {RequestHandler}
  */
  const getAll = async (req, res) => {
-	const certificates = (await Certificate.find({}, {
+	if(req.query.tags){
+		try{
+		const formData = req.query.tags;
+		const decodedData = decodeURIComponent(formData);
+		const jsonObject = JSON.parse(decodedData);
+		req.query["tags"] = {"$in": jsonObject};
+		}catch(e){
+			return res.status(statusCode.BAD_REQUEST).send(`Bad JSON object encoding ${e.message}`);
+		}
+	}
+
+	const certificates = (await Certificate.find(req.query, {
 		_id: 0,
 		uid: 1
 	})).map(t => t.uid);

--- a/src/controllers/template.js
+++ b/src/controllers/template.js
@@ -207,7 +207,18 @@ const getSingle = async (req, res) => {
  * @type {RequestHandler}
  */
 const getAll = async (req, res) => {
-	const templates = (await Template.find({}, {
+	if(req.query.tags){
+		try{
+		const formData = req.query.tags;
+		const decodedData = decodeURIComponent(formData);
+		const jsonObject = JSON.parse(decodedData);
+		req.query["tags"] = {"$in": jsonObject};
+		}catch(e){
+			return res.status(statusCode.BAD_REQUEST).send(`Bad JSON object encoding ${e.message}`);
+		}
+	}
+
+	const templates = (await Template.find(req.query, {
 		_id: 0,
 		name: 1
 	})).map(t => t.name);

--- a/src/controllers/template.js
+++ b/src/controllers/template.js
@@ -212,9 +212,9 @@ const getAll = async (req, res) => {
 		const formData = req.query.tags;
 		const decodedData = decodeURIComponent(formData);
 		const jsonObject = JSON.parse(decodedData);
-		req.query["tags"] = {"$in": jsonObject};
+		req.query['tags'] = {'$in': jsonObject};
 		}catch(e){
-			return res.status(statusCode.BAD_REQUEST).send(`Bad JSON object encoding ${e.message}`);
+			return res.status(statusCode.BAD_REQUEST).send(`Failed to get templates: Bad fromat ${e.message}`);
 		}
 	}
 


### PR DESCRIPTION
closes #55 

Added changes in   ```controllers/certificate.js``` and ```controllers/template.js``` to support multiple query parameters.

1. controllers/certificate.js 
 - if req.query contains tags check if value of req.query.tags can be decoded into JSON object
 - if err while decoding send 400 Bad request message
 - else use req.query object to filter certificates (in case of no parameters req.query={})
```
if(req.query.tags){
		try{
		const formData = req.query.tags;
		const decodedData = decodeURIComponent(formData);
		const jsonObject = JSON.parse(decodedData);
		req.query['tags'] = {'$in': jsonObject};
		}catch(e){
			return res.status(statusCode.BAD_REQUEST).send(`Failed to get certificates: Bad fromat ${e.message}`);
		}
	}

	const certificates = (await Certificate.find(req.query, {
		_id: 0,
		uid: 1
	})).map(t => t.uid);
```
2. controllers/template.js
 - if req.query contains tags check if value of req.query.tags can be decoded into JSON object
 - if err while decoding send 400 Bad request message
 - else use req.query object to filter templates (in case of no parameters req.query={})
 ```
if(req.query.tags){
		try{
		const formData = req.query.tags;
		const decodedData = decodeURIComponent(formData);
		const jsonObject = JSON.parse(decodedData);
		req.query['tags'] = {'$in': jsonObject};
		}catch(e){
			return res.status(statusCode.BAD_REQUEST).send(`Failed to get templates: Bad fromat ${e.message}`);
		}
	}

	const templates = (await Template.find(req.query, {
		_id: 0,
		name: 1
	})).map(t => t.name);
```